### PR TITLE
Adds ghc-prim to build-depends.

### DIFF
--- a/processing.cabal
+++ b/processing.cabal
@@ -70,6 +70,7 @@ Library
     , mainland-pretty
     , blaze-html
     , multiset
+    , ghc-prim
   Exposed-modules:
     -- Core modules
     Graphics.Web.Processing.Core.Types


### PR DESCRIPTION
I had to add this to get the version on Hackage to compile with GHC version 7.4.1.  If this is just an issue with my setup, please ignore.  
